### PR TITLE
modify UI of metric page and fix error message on course detail page

### DIFF
--- a/frontend/src/pages/CourseDetail/CourseDetail.vue
+++ b/frontend/src/pages/CourseDetail/CourseDetail.vue
@@ -164,18 +164,20 @@ export default {
               duration: moment.duration(startTime.diff(endTime)).humanize()
             }
           });
-          this.captures = values[2].data.map(capture => {
-            const start = moment(capture.start);
-            const end = moment(capture.end);
-            return {
-              id: capture.sessionId,
-              captureId: capture.captureId,
-              labName: capture.sessionName,
-              date: start.format("L"),
-              time: `${start.format("LT")}`,
-              duration: moment.duration(start.diff(end)).humanize()
-            }
-          });
+          if(typeof values[2] !== "undefined"){
+            this.captures = values[2].data.map(capture => {
+              const start = moment(capture.start);
+              const end = moment(capture.end);
+              return {
+                id: capture.sessionId,
+                captureId: capture.captureId,
+                labName: capture.sessionName,
+                date: start.format("L"),
+                time: `${start.format("LT")}`,
+                duration: moment.duration(start.diff(end)).humanize()
+              }
+            });
+          }
         });
     }
   }

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -26,116 +26,119 @@
     <v-row>
       <v-col>
         <SectionCard title="Capture Data">
-                <v-container fluid>
-          <template>
-    <v-row>
-      <v-col>
-        <v-select
-        label="Select Course"
-        :items="courses"
-        item-text="courseName"
-        item-value="courseId"
-        v-model="courseSelected"
-        v-on:change="getLabsByCourseId"
-        dense 
-        class="ml-3"
-        clearable
-        >
-        </v-select>
-      </v-col>
-      <v-col>
-        <v-select
-        v-if="courseSelected"
-        label="Select Lab"
-        :items="labs"
-        item-text="sessionName"
-        item-value="sessionId"
-        v-model="labSelected"
-        v-on:change="getCapturesByLabId"
-        dense 
-        class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>
-      </v-col>
-      <v-col>
-        <v-select 
-        v-if="labSelected"
-        label="Select Capture"
-        :items="captures"
-        item-text="captureId"
-        item-value="captureId"
-        v-model="captureSelected"
-        v-on:change="loadData"
-        dense class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>
-      </v-col>
+          <v-container fluid>
+            <template>
+              <v-row>
+                <div style="padding-left:12;">hint for capture data</div>
+              </v-row>
+              <v-row>
+                <v-col>
+                  <v-select
+                  label="Select Course"
+                  :items="courses"
+                  item-text="courseName"
+                  item-value="courseId"
+                  v-model="courseSelected"
+                  v-on:change="getLabsByCourseId"
+                  dense 
+                  class="ml-3"
+                  clearable
+                  >
+                  </v-select>
+                </v-col>
+                <v-col>
+                  <v-select
+                  v-if="courseSelected"
+                  label="Select Lab"
+                  :items="labs"
+                  item-text="sessionName"
+                  item-value="sessionId"
+                  v-model="labSelected"
+                  v-on:change="getCapturesByLabId"
+                  dense 
+                  class="ml-3"
+                  clearable
+                  >
+                  </v-select>
+                  <v-select
+                  v-else
+                  disabled
+                  dense class="ml-3">
+                  </v-select>
+                </v-col>
+                <v-col>
+                  <v-select 
+                  v-if="labSelected"
+                  label="Select Capture"
+                  :items="captures"
+                  item-text="captureId"
+                  item-value="captureId"
+                  v-model="captureSelected"
+                  v-on:change="loadData"
+                  dense class="ml-3"
+                  clearable
+                  >
+                  </v-select>
+                  <v-select
+                  v-else
+                  disabled
+                  dense class="ml-3">
+                  </v-select>
+                </v-col>
 
-      <v-btn 
-      v-if="courseSelected" 
-      color="primary" 
-      v-on:click="exportData">
-        Export Data
-      </v-btn>
-      <v-btn 
-      v-else
-      disabled
-      color="primary" 
-      v-on:click="exportData">
-        Export Data
-      </v-btn>
-    </v-row>
+                <v-btn 
+                v-if="courseSelected" 
+                color="primary" 
+                v-on:click="exportData">
+                  Export Data
+                </v-btn>
+                <v-btn 
+                v-else
+                disabled
+                color="primary" 
+                v-on:click="exportData">
+                  Export Data
+                </v-btn>
+              </v-row>
 
-    <v-row>
-      <v-col v-if="sessionInteractionCountsMax">
-        <GlobalBar v-if="sessionInteractionCountsMax > 0"
-          :title="`Interactions By Session`"
-          :series="[{ name: `Interactions`, data: sessionInteractionCounts }]"
-          :xcategories="sessionIds" 
-          :xtitle="`Session`" 
-          :ytitle="`Count`"
-          :ymin="0"
-          :ymax="sessionInteractionCountsMax"
-        />
-      </v-col>
+              <v-row>
+                <v-col v-if="sessionInteractionCountsMax">
+                  <GlobalBar v-if="sessionInteractionCountsMax > 0"
+                    :title="`Interactions By Session`"
+                    :series="[{ name: `Interactions`, data: sessionInteractionCounts }]"
+                    :xcategories="sessionIds" 
+                    :xtitle="`Session`" 
+                    :ytitle="`Count`"
+                    :ymin="0"
+                    :ymax="sessionInteractionCountsMax"
+                  />
+                </v-col>
 
-      <v-col v-if="interactionTypeCountsMax">
-        <GlobalBar v-if="interactionTypeCountsMax > 0"
-          :title="`Interactions By Type`"
-          :series="[{ name: `Interactions`, data: interactionTypeCounts }]"
-          :xcategories="interactionTypes" 
-          :xtitle="`Type`" 
-          :ytitle="`Count`"
-          :ymin="0"
-          :ymax="interactionTypeCountsMax"
-        />
-      </v-col>
-    </v-row>
-            <v-row>
-            <v-text-field
-                class="ma-3"
-                clearable
-                dense
-                outlined
-                v-model="search"
-                append-icon="mdi-magnify"
-                label="Search"
-                single-line
-            ></v-text-field>
-            </v-row>
-          </template>
+                <v-col v-if="interactionTypeCountsMax">
+                  <GlobalBar v-if="interactionTypeCountsMax > 0"
+                    :title="`Interactions By Type`"
+                    :series="[{ name: `Interactions`, data: interactionTypeCounts }]"
+                    :xcategories="interactionTypes" 
+                    :xtitle="`Type`" 
+                    :ytitle="`Count`"
+                    :ymin="0"
+                    :ymax="interactionTypeCountsMax"
+                  />
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-text-field
+                    class="ma-3"
+                    clearable
+                    dense
+                    outlined
+                    v-model="search"
+                    append-icon="mdi-magnify"
+                    label="Search"
+                    single-line
+                ></v-text-field>
+              </v-row>
+            </template>
           </v-container fluid>
           <v-container fluid>
             <v-data-table
@@ -160,6 +163,9 @@
       <SectionCard title="data request">
         <v-container fluid>
         <template>
+          <v-row>
+            <div style="padding-left:12;">hint for data request</div>
+          </v-row>
           <v-row>
             <v-col>
               <v-select
@@ -213,6 +219,8 @@
               dense class="ml-3">
               </v-select>      
             </v-col>
+          </v-row>
+          <v-row>
             <v-col>
               <v-select 
               v-if="csvLabSelected"
@@ -221,6 +229,7 @@
               v-model="typeSelected"
               dense class="ml-3"
               clearable
+              @change="changeFunctionType"
               >
               </v-select>
               <v-select
@@ -230,7 +239,6 @@
               </v-select>
             </v-col>
           </v-row>
-
           <v-row>
             <v-col>
               <v-select
@@ -670,6 +678,10 @@ export default {
           this.dialog = true;
         }
       })
+    },
+    changeFunctionType(){
+        this.interactionSelected=null;
+        this.entitySelected=null;
     }
   }
 }

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -698,7 +698,6 @@ export default {
       }
     },
     changeRequest(){
-      console.log(this.csvCaptureSelected,this.typeSelected,this.entitySelected,this.interactionSelected);
       if((this.csvLabSelected!==null && this.csvLabSelected!==undefined) && (this.csvCaptureSelected!==null && this.csvCaptureSelected!==undefined) && (this.interactionSelected!==null && this.interactionSelected!==undefined) && (this.entitySelected!==null && this.entitySelected!==undefined) && this.typeSelected =='user energy'){
         this.submitDataRequest = false;
       }

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -25,6 +25,11 @@
     
     <v-row>
       <v-col>
+        <SectionCard title="Capture Data">
+                <v-container fluid>
+          <template>
+    <v-row>
+      <v-col>
         <v-select
         label="Select Course"
         :items="courses"
@@ -118,18 +123,20 @@
         />
       </v-col>
     </v-row>
-    <v-row>
-      <v-col>
-        <SectionCard title="Capture Data">
-          <template v-slot:actions>
+            <v-row>
             <v-text-field
-              v-model="search"
-              append-icon="mdi-magnify"
-              label="Search"
-              single-line
-              hide-details
+                class="ma-3"
+                clearable
+                dense
+                outlined
+                v-model="search"
+                append-icon="mdi-magnify"
+                label="Search"
+                single-line
             ></v-text-field>
+            </v-row>
           </template>
+          </v-container fluid>
           <v-container fluid>
             <v-data-table
                   :headers="interactionTableHeaders"
@@ -149,133 +156,133 @@
     </v-row>
 
     <v-row>
-      <v-col>
-        <v-select
-        label="Select Course"
-        :items="courses"
-        item-text="courseName"
-        item-value="courseId"
-        v-model="csvCourseSelected"
-        v-on:change="getcsvLabsByCourseId"
-        dense 
-        class="ml-3"
-        clearable
-        >
-        </v-select>
-      </v-col>
-      <v-col>
-        <v-select
-        v-if="csvCourseSelected"
-        label="Select Lab"
-        :items="csvlabs"
-        item-text="sessionName"
-        item-value="sessionId"
-        v-model="csvLabSelected"
-        v-on:change="getCsvCapturesByLabId"
-        dense 
-        class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>
-      </v-col>
-      <v-col>
-        <v-select 
-        v-if="csvLabSelected"
-        label="Select Capture"
-        :items="captures"
-        item-text="captureId"
-        item-value="captureId"
-        v-model="csvCaptureSelected"
-        dense class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>      
-      </v-col>
-      <v-col>
-        <v-select 
-        v-if="csvLabSelected"
-        label="type"
-        :items="type"
-        v-model="typeSelected"
-        dense class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>
-      </v-col>
-    </v-row>
-
-    <v-row>
-      <v-col>
-        <v-select
-        v-if="typeSelected =='user energy' || typeSelected =='aggregate interaction'"
-        label="Select interaction type"
-        :items="interaction_type"
-        item-text="text"
-        item-value="value"
-        v-model="interactionSelected"
-        dense class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>
-      </v-col>
-      <v-col>
-        <v-select
-        v-if="typeSelected =='user energy'"
-        label="Select entity type"
-        :items="entity_type"
-        item-text="text"
-        item-value="value"
-        v-model="entitySelected"
-        dense 
-        class="ml-3"
-        clearable
-        >
-        </v-select>
-        <v-select
-        v-else
-        disabled
-        dense class="ml-3">
-        </v-select>
-      </v-col>
-      <v-btn
-      v-if="(csvCaptureSelected && interactionSelected && entitySelected && typeSelected =='user energy') || (typeSelected =='aggregate interaction' && interactionSelected && csvCaptureSelected) || (typeSelected =='aggregate user' && csvCaptureSelected)"
-      color="primary" 
-      v-on:click="getCsv">
-        Export csv file
-      </v-btn>
-      <v-btn
-      v-else
-      disabled
-      color="primary" 
-      v-on:click="getCsv">
-        Export csv file
-      </v-btn>
-    </v-row>
-    <v-row>
     <v-col>
-      <SectionCard title="data request history">
+      <SectionCard title="data request">
         <v-container fluid>
         <template>
+          <v-row>
+            <v-col>
+              <v-select
+              label="Select Course"
+              :items="courses"
+              item-text="courseName"
+              item-value="courseId"
+              v-model="csvCourseSelected"
+              v-on:change="getcsvLabsByCourseId"
+              dense 
+              class="ml-3"
+              clearable
+              >
+              </v-select>
+            </v-col>
+            <v-col>
+              <v-select
+              v-if="csvCourseSelected"
+              label="Select Lab"
+              :items="csvlabs"
+              item-text="sessionName"
+              item-value="sessionId"
+              v-model="csvLabSelected"
+              v-on:change="getCsvCapturesByLabId"
+              dense 
+              class="ml-3"
+              clearable
+              >
+              </v-select>
+              <v-select
+              v-else
+              disabled
+              dense class="ml-3">
+              </v-select>
+            </v-col>
+            <v-col>
+              <v-select 
+              v-if="csvLabSelected"
+              label="Select Capture"
+              :items="captures"
+              item-text="captureId"
+              item-value="captureId"
+              v-model="csvCaptureSelected"
+              dense class="ml-3"
+              clearable
+              >
+              </v-select>
+              <v-select
+              v-else
+              disabled
+              dense class="ml-3">
+              </v-select>      
+            </v-col>
+            <v-col>
+              <v-select 
+              v-if="csvLabSelected"
+              label="type"
+              :items="type"
+              v-model="typeSelected"
+              dense class="ml-3"
+              clearable
+              >
+              </v-select>
+              <v-select
+              v-else
+              disabled
+              dense class="ml-3">
+              </v-select>
+            </v-col>
+          </v-row>
+
+          <v-row>
+            <v-col>
+              <v-select
+              v-if="typeSelected =='user energy' || typeSelected =='aggregate interaction'"
+              label="Select interaction type"
+              :items="interaction_type"
+              item-text="text"
+              item-value="value"
+              v-model="interactionSelected"
+              dense class="ml-3"
+              clearable
+              >
+              </v-select>
+              <v-select
+              v-else
+              disabled
+              dense class="ml-3">
+              </v-select>
+            </v-col>
+            <v-col>
+              <v-select
+              v-if="typeSelected =='user energy'"
+              label="Select entity type"
+              :items="entity_type"
+              item-text="text"
+              item-value="value"
+              v-model="entitySelected"
+              dense 
+              class="ml-3"
+              clearable
+              >
+              </v-select>
+              <v-select
+              v-else
+              disabled
+              dense class="ml-3">
+              </v-select>
+            </v-col>
+            <v-btn
+            v-if="(csvCaptureSelected && interactionSelected && entitySelected && typeSelected =='user energy') || (typeSelected =='aggregate interaction' && interactionSelected && csvCaptureSelected) || (typeSelected =='aggregate user' && csvCaptureSelected)"
+            color="primary" 
+            v-on:click="getCsv">
+              Export csv file
+            </v-btn>
+            <v-btn
+            v-else
+            disabled
+            color="primary" 
+            v-on:click="getCsv">
+              Export csv file
+            </v-btn>
+          </v-row>
         <v-data-table
           :headers="csvHeaders"
           :items="csvRecord"
@@ -289,30 +296,30 @@
               mdi-cloud-download
             </v-icon>
           </template>
-<template v-slot:top>
-  <div class="text-center">
-    <v-dialog
-      v-model="dialog"
-      max-width="500"
-    >
-      <v-card>
-        <v-card-title class="text-h5">
-          file processing, please come back later
-        </v-card-title>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn
-            color="primary"
-            text
-            @click="dialog = false"
-          >
-            close
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
-</template>
+          <template v-slot:top>
+            <div class="text-center">
+              <v-dialog
+                v-model="dialog"
+                max-width="500"
+              >
+                <v-card>
+                  <v-card-title class="text-h5">
+                    file processing, please come back later
+                  </v-card-title>
+                  <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn
+                      color="primary"
+                      text
+                      @click="dialog = false"
+                    >
+                      close
+                    </v-btn>
+                  </v-card-actions>
+                </v-card>
+              </v-dialog>
+            </div>
+          </template>
         </v-data-table>
         </template>
         </v-container>


### PR DESCRIPTION
# Error fix and modify metric page UI

move form of sending data request and lab capture into separate blocks to make it more clear for users. Also fix error message on course detail page.
Fixes #41

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [ ] Change that requires a documentation update

# How Has This Been Tested?

error fix for course detail page: enter course detail page for courses without capture, there should be no error message in console now.
metric page UI: the form for sending request on metric page should be in the same block with their table.

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test

**Test Configuration**:

Chrome Version 96.0.4664.45 (Official Build) (32-bit)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas that are not self-documenting
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings 
- [x] My changes have no unnecessary logging
- [ ] I have added tests that prove my fix is effective or that my feature works, for sufficiently complex features
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Sensitive info like tokens, secrets, and passwords have been removed before submitting

Modified from this article:
Phillip Johnston, “A GitHub Pull Request Template for Your Projects - Embedded Artistry,” Embedded Artistry, Aug. 04, 2017. https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ (accessed Jul. 22, 2021).
