### PR TITLE
Raw export download (One capture at a time)

### DIFF
--- a/backend/config_template.js
+++ b/backend/config_template.js
@@ -17,8 +17,8 @@ module.exports = {
         region: '',
         bucket: ''
     },
+    captures: '/komodo/captures',
     jwt: '',
     TWILIO_ACCOUNT_SID: '',
     TWILIO_AUTH_TOKEN: ''
 };
-

--- a/backend/controller/data.js
+++ b/backend/controller/data.js
@@ -1,59 +1,120 @@
 const express = require("express");
-const { getAllInteractions, getAllRawCapture, getAllRawLab, getAllRawCourse, getAllCsvExport, exportMetricCsv, getDownloadLink } = require("../service/data");
-const dataController = express.Router();
+const path = require("path");
 
+const { getAllInteractions, getCaptureJSONFile, getAllRawCapture, getAllRawLab, getAllRawCourse, getAllCsvExport, exportMetricCsv, getDownloadLink } = require("../service/data");
+const dataController = express.Router();
 
 dataController.get("/", 
   async (req, res) => {
     res.send("/data is working");
-});
+  }
+);
 
 dataController.get("/interactions",
   async (req, res) => {
     let results = await getAllInteractions();
     res.status(200).json(results.data);
-  });
+  }
+);
+
+dataController.get("/export/json/capture/:captureId",
+  async (req, res) => {
+    const { captureId } = req.params;
+
+    let results = await getCaptureJSONFile(captureId);
+
+    if (!results || results == undefined) {
+      console.error("results.data was null or undefined");
+
+      return;
+    }
+
+    if (!results.data || results.data == undefined) {
+      console.error("results.data was null or undefined");
+
+      return;
+    }
+
+    const filename = "data";
+
+    const ext = ""; // ext must start with a "." unless there's no extension
+
+    const fullFilename = `${filename}${ext}`;
+
+    const pathAndFilename = path.join(results.data, fullFilename);
+    
+    const options = {
+      root: results.data,
+      headers: {
+        'x-timestamp': Date.now(),
+        'x-sent': true
+      }
+    };
+
+    // res.sendFile(fullFilename, options, function (err) {
+    //   if (err) {
+    //     console.error(err);
+    //   } else {
+    //     console.log('Sent:', fullFilename);
+    //   }
+    // });
+
+    res.download(pathAndFilename, function (err) {
+      if (err) {
+        console.error(err);
+      } else {
+        //console.log('Sent:', fullFilename);
+      }
+    })
+  }
+);
 
 dataController.get("/export/raw/capture/:captureId",
-async (req, res) => {
-  const { captureId } = req.params;
-  let results = await getAllRawCapture(captureId);
-  res.status(200).json(results.data);
-});
+  async (req, res) => {
+    const { captureId } = req.params;
+    let results = await getAllRawCapture(captureId);
+    res.status(200).json(results.data);
+  }
+);
 
 dataController.get("/export/raw/lab/:labId",
-async (req, res) => {
-  const { labId } = req.params;
-  let results = await getAllRawLab(labId);
-  res.status(200).json(results.data);
-});
+  async (req, res) => {
+    const { labId } = req.params;
+    let results = await getAllRawLab(labId);
+    res.status(200).json(results.data);
+  }
+);
 
 dataController.get("/export/raw/course/:courseId",
-async (req, res) => {
-  const { courseId } = req.params;
-  let results = await getAllRawCourse(courseId);
-  res.status(200).json(results.data);
-});
+  async (req, res) => {
+    const { courseId } = req.params;
+    let results = await getAllRawCourse(courseId);
+    res.status(200).json(results.data);
+  }
+);
 
 dataController.post("/",
-async (req, res) => {
-  const data = req.body;
-  let results = await exportMetricCsv(data);
-  res.status(200).json(results.data);
-});
+  async (req, res) => {
+    const data = req.body;
+    let results = await exportMetricCsv(data);
+    res.status(200).json(results.data);
+  }
+);
 
 dataController.post("/request",
-async (req, res) => {
-  const data = req.body;
-  let results = await getAllCsvExport(data);
-  res.status(200).json(results.data);
-});
+  async (req, res) => {
+    const data = req.body;
+    let results = await getAllCsvExport(data);
+    res.status(200).json(results.data);
+  }
+);
 
 dataController.post("/download",
-async (req, res) => {
-  const data = req.body;
-  let results = await getDownloadLink(data);
-  res.status(200).json(results.data);
-});
+  async (req, res) => {
+    const data = req.body;
+    let results = await getDownloadLink(data);
+    res.status(200).json(results.data);
+  }
+);
 
 module.exports = dataController;

--- a/backend/controller/data.js
+++ b/backend/controller/data.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const path = require("path");
 
-const { getAllInteractions, getRawExportFilePath, getCombinedCapture, getCombinedLabCaptures, getCombinedCourseCaptures, getAllCsvExport, exportMetricCsv, getDownloadLink } = require("../service/data");
+const { getAllInteractions, getRawExportFilePath, getAllCsvExport, exportMetricCsv, getDownloadLink } = require("../service/data");
 const dataController = express.Router();
 
 dataController.get("/", 
@@ -40,30 +40,6 @@ dataController.get("/export/raw/capture/:captureId",
         console.error(err);
       }
     });
-  }
-);
-
-dataController.get("/export/combined/capture/:captureId",
-  async (req, res) => {
-    const { captureId } = req.params;
-    let results = await getCombinedCapture(captureId);
-    res.status(200).json(results.data);
-  }
-);
-
-dataController.get("/export/combined/lab/:labId",
-  async (req, res) => {
-    const { labId } = req.params;
-    let results = await getCombinedLabCaptures(labId);
-    res.status(200).json(results.data);
-  }
-);
-
-dataController.get("/export/combined/course/:courseId",
-  async (req, res) => {
-    const { courseId } = req.params;
-    let results = await getCombinedCourseCaptures(courseId);
-    res.status(200).json(results.data);
   }
 );
 

--- a/backend/controller/data.js
+++ b/backend/controller/data.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const path = require("path");
 
-const { getAllInteractions, getCaptureJSONFile, getAllRawCapture, getAllRawLab, getAllRawCourse, getAllCsvExport, exportMetricCsv, getDownloadLink } = require("../service/data");
+const { getAllInteractions, getRawExportFilePath, getCombinedCapture, getCombinedLabCaptures, getCombinedCourseCaptures, getAllCsvExport, exportMetricCsv, getDownloadLink } = require("../service/data");
 const dataController = express.Router();
 
 dataController.get("/", 
@@ -17,14 +17,14 @@ dataController.get("/interactions",
   }
 );
 
-dataController.get("/export/json/capture/:captureId",
+dataController.get("/export/raw/capture/:captureId",
   async (req, res) => {
     const { captureId } = req.params;
 
-    let results = await getCaptureJSONFile(captureId);
+    let results = await getRawExportFilePath(captureId);
 
     if (!results || results == undefined) {
-      console.error("results.data was null or undefined");
+      console.error("results was null or undefined");
 
       return;
     }
@@ -35,60 +35,34 @@ dataController.get("/export/json/capture/:captureId",
       return;
     }
 
-    const filename = "data";
-
-    const ext = ""; // ext must start with a "." unless there's no extension
-
-    const fullFilename = `${filename}${ext}`;
-
-    const pathAndFilename = path.join(results.data, fullFilename);
-    
-    const options = {
-      root: results.data,
-      headers: {
-        'x-timestamp': Date.now(),
-        'x-sent': true
-      }
-    };
-
-    // res.sendFile(fullFilename, options, function (err) {
-    //   if (err) {
-    //     console.error(err);
-    //   } else {
-    //     console.log('Sent:', fullFilename);
-    //   }
-    // });
-
-    res.download(pathAndFilename, function (err) {
+    res.download(results.data, function (err) {
       if (err) {
         console.error(err);
-      } else {
-        //console.log('Sent:', fullFilename);
       }
-    })
+    });
   }
 );
 
-dataController.get("/export/raw/capture/:captureId",
+dataController.get("/export/combined/capture/:captureId",
   async (req, res) => {
     const { captureId } = req.params;
-    let results = await getAllRawCapture(captureId);
+    let results = await getCombinedCapture(captureId);
     res.status(200).json(results.data);
   }
 );
 
-dataController.get("/export/raw/lab/:labId",
+dataController.get("/export/combined/lab/:labId",
   async (req, res) => {
     const { labId } = req.params;
-    let results = await getAllRawLab(labId);
+    let results = await getCombinedLabCaptures(labId);
     res.status(200).json(results.data);
   }
 );
 
-dataController.get("/export/raw/course/:courseId",
+dataController.get("/export/combined/course/:courseId",
   async (req, res) => {
     const { courseId } = req.params;
-    let results = await getAllRawCourse(courseId);
+    let results = await getCombinedCourseCaptures(courseId);
     res.status(200).json(results.data);
   }
 );

--- a/backend/service/data.js
+++ b/backend/service/data.js
@@ -45,33 +45,6 @@ const getRawExportFilePath = async(idAndTimestamp) => {
   };
 };
 
-const getCombinedCapture = async(id) => {
-  const results = {}
-  results.pos = await pool.execute(dataQuery.getRawPosCapture, [id]);
-  results.int = await pool.execute(dataQuery.getRawIntCapture, [id]);
-  return {
-    data: results
-  };
-};
-
-const getCombinedLabCaptures = async(id) => {
-  const results = {}
-  results.pos = await pool.execute(dataQuery.getRawPosLab, [id]);
-  results.int = await pool.execute(dataQuery.getRawIntLab, [id]);
-  return {
-    data: results
-  };
-};
-
-const getCombinedCourseCaptures = async(id) => {
-  const results = {}
-  results.pos = await pool.execute(dataQuery.getRawPosCourse, [id]);
-  results.int = await pool.execute(dataQuery.getRawIntCourse, [id]);
-  return {
-    data: results
-  };
-};
-
 const exportMetricCsv = async(data) => {
   let request = [data.captureId, data.clientId, data.type, 0, data]
   results = await pool.execute(dataQuery.insertRequest,request);
@@ -153,9 +126,6 @@ const getDownloadLink = async(request) => {
 module.exports = {
   getAllInteractions,
   getRawExportFilePath,
-  getCombinedCapture,
-  getCombinedLabCaptures,
-  getCombinedCourseCaptures,
   getAllCsvExport,
   exportMetricCsv,
   getDownloadLink

--- a/backend/service/data.js
+++ b/backend/service/data.js
@@ -10,6 +10,8 @@ const path = require('path');
 const pool = require("./index");
 const dataQuery = require("../query/data");
 
+const CAPTURE_FILE_NAME_AND_EXTENSION = "data";
+
 const getAllInteractions = async() => {
   const results = await pool.execute(dataQuery.getAllInteractions);
   return {
@@ -17,7 +19,7 @@ const getAllInteractions = async() => {
   };
 };
 
-const getCaptureJSONFile = async(idAndTimestamp) => {
+const getRawExportFilePath = async(idAndTimestamp) => {
   // from express, generate the capture path directory
   // return that file?
   // return a download URL?
@@ -36,12 +38,14 @@ const getCaptureJSONFile = async(idAndTimestamp) => {
 
   const directory = path.join(config.captures, id, timestamp);
 
+  const pathAndFilename = path.join(directory, CAPTURE_FILE_NAME_AND_EXTENSION);
+
   return {
-    data: directory
+    data: pathAndFilename
   };
 };
 
-const getAllRawCapture = async(id) => {
+const getCombinedCapture = async(id) => {
   const results = {}
   results.pos = await pool.execute(dataQuery.getRawPosCapture, [id]);
   results.int = await pool.execute(dataQuery.getRawIntCapture, [id]);
@@ -50,7 +54,7 @@ const getAllRawCapture = async(id) => {
   };
 };
 
-const getAllRawLab = async(id) => {
+const getCombinedLabCaptures = async(id) => {
   const results = {}
   results.pos = await pool.execute(dataQuery.getRawPosLab, [id]);
   results.int = await pool.execute(dataQuery.getRawIntLab, [id]);
@@ -59,7 +63,7 @@ const getAllRawLab = async(id) => {
   };
 };
 
-const getAllRawCourse = async(id) => {
+const getCombinedCourseCaptures = async(id) => {
   const results = {}
   results.pos = await pool.execute(dataQuery.getRawPosCourse, [id]);
   results.int = await pool.execute(dataQuery.getRawIntCourse, [id]);
@@ -148,10 +152,10 @@ const getDownloadLink = async(request) => {
 
 module.exports = {
   getAllInteractions,
-  getCaptureJSONFile,
-  getAllRawCapture,
-  getAllRawLab,
-  getAllRawCourse,
+  getRawExportFilePath,
+  getCombinedCapture,
+  getCombinedLabCaptures,
+  getCombinedCourseCaptures,
   getAllCsvExport,
   exportMetricCsv,
   getDownloadLink

--- a/backend/service/data.js
+++ b/backend/service/data.js
@@ -1,10 +1,12 @@
+'esversion: 6';
+
 const fs = require('fs');
 const AWS = require('aws-sdk');
 const config = require("../config");
 AWS.config.update(config.aws);
 const s3 = new AWS.S3();
 const BUCKET_NAME = config.aws.bucket;
-
+const path = require('path');
 const pool = require("./index");
 const dataQuery = require("../query/data");
 
@@ -12,8 +14,32 @@ const getAllInteractions = async() => {
   const results = await pool.execute(dataQuery.getAllInteractions);
   return {
     data: results[0]
+  };
+};
+
+const getCaptureJSONFile = async(idAndTimestamp) => {
+  // from express, generate the capture path directory
+  // return that file?
+  // return a download URL?
+
+  const splitIdAndTimestamp = idAndTimestamp.split("_");
+
+  if (splitIdAndTimestamp.length != 2) {
+    console.error("string should be formatted like <string>_<timestamp>");
+
+    return;
   }
-}
+
+  const id = splitIdAndTimestamp[0];
+
+  const timestamp = splitIdAndTimestamp[1];
+
+  const directory = path.join(config.captures, id, timestamp);
+
+  return {
+    data: directory
+  };
+};
 
 const getAllRawCapture = async(id) => {
   const results = {}
@@ -21,8 +47,8 @@ const getAllRawCapture = async(id) => {
   results.int = await pool.execute(dataQuery.getRawIntCapture, [id]);
   return {
     data: results
-  }
-}
+  };
+};
 
 const getAllRawLab = async(id) => {
   const results = {}
@@ -30,8 +56,8 @@ const getAllRawLab = async(id) => {
   results.int = await pool.execute(dataQuery.getRawIntLab, [id]);
   return {
     data: results
-  }
-}
+  };
+};
 
 const getAllRawCourse = async(id) => {
   const results = {}
@@ -39,8 +65,8 @@ const getAllRawCourse = async(id) => {
   results.int = await pool.execute(dataQuery.getRawIntCourse, [id]);
   return {
     data: results
-  }
-}
+  };
+};
 
 const exportMetricCsv = async(data) => {
   let request = [data.captureId, data.clientId, data.type, 0, data]
@@ -49,8 +75,8 @@ const exportMetricCsv = async(data) => {
     data: {
       status: "success"
     }
-  }
-}
+  };
+};
 
 const getAllCsvExport = async(data) => {
   let userId = data.userId;
@@ -59,16 +85,16 @@ const getAllCsvExport = async(data) => {
     for(i=0;i<results[0].length;i++){
       results[0][i].message = JSON.parse(results[0][i].message);
     }
+
     return {
       data: results[0]
     };
   }else{
     return {
       data: []
-    }
+    };
   }
-
-}
+};
 
 const getDownloadLink = async(request) => {
   let requestId = request.requestId;
@@ -78,7 +104,7 @@ const getDownloadLink = async(request) => {
       data: {
         status: "processing"
       }
-    })
+    });
   }else{
     if(results[0][0].url == null){
       // Read content from the file
@@ -122,6 +148,7 @@ const getDownloadLink = async(request) => {
 
 module.exports = {
   getAllInteractions,
+  getCaptureJSONFile,
   getAllRawCapture,
   getAllRawLab,
   getAllRawCourse,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     networks:
       - proxy
       - komodo_internal
+    volumes: 
+      - ../captures:/komodo/captures 
+      # this requires that komodo-portal and captures are in the same directory
+      # this should be a bind mount and not a volume
 
   frontend:
     build: ./frontend

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -564,52 +564,6 @@ export default {
       
       downloadCaptureJSONFile({ captureId });
     },
-    formatAndDownload(res) {
-      let intData = res.data.int;
-      let posData = res.data.pos;
-
-      let intFields = [];
-      intData[1].forEach(field => {
-        intFields.push(field.name)
-      });
-      const intOpts = { intFields };
-      
-      let posFields = [];
-      posData[1].forEach(field => {
-        posFields.push(field.name)
-      });
-      const posOpts = { posFields };
-
-      try {
-        const encoding = "data:text/csv;charset=utf-8,";
-
-        // interactions csv
-        if (intData[0].length) {
-          const intParser = new Parser(intOpts);
-          const intCsv = encoding+intParser.parse(intData[0]);
-          let encodedUri = encodeURI(intCsv);
-          let link = document.createElement("a");
-          link.setAttribute("href", encodedUri);
-          link.setAttribute("download", `${this.rawExportCaptureSelected || this.rawExportLabSelected || this.rawExportCourseSelected}_interactions.csv`);
-          document.body.appendChild(link); // Required for FF
-          link.click();
-        }
-
-        // positions csv
-        if (posData[0].length) {
-          const posParser = new Parser(posOpts);
-          const posCsv = encoding+posParser.parse(posData[0]);
-          let encodedUri = encodeURI(posCsv);
-          let link = document.createElement("a");
-          link.setAttribute("href", encodedUri);
-          link.setAttribute("download", `${this.rawExportCaptureSelected || this.rawExportLabSelected || this.rawExportCourseSelected}_positions.csv`);
-          document.body.appendChild(link); // Required for FF
-          link.click();
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    },
     getMetrics() {
       getInteractionData().then(data => {
         if (data.data) {

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -337,7 +337,7 @@
 <script>
 import GlobalBar from "../../components/Charts/GlobalBar";
 import SectionCard from "../../components/Cards/SectionCard";
-import { getInteractionData, getCombinedCourseCaptures, getCombinedLabCaptures, getCombinedCapture, getAllDataRequest, exportMetricCsv, getDownloadLink, downloadCaptureJSONFile } from "../../requests/data";
+import { getInteractionData, getAllDataRequest, exportMetricCsv, getDownloadLink, downloadCaptureJSONFile } from "../../requests/data";
 import { getCourseListByInstructor, getLabList, getCaptureList } from "../../requests/course";
 import { Parser } from "json2csv";
 

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -87,7 +87,7 @@
                 </v-col>
 
                 <v-btn 
-                v-if="rawExportCourseSelected" 
+                v-if="rawExportCaptureSelected" 
                 color="primary" 
                 v-on:click="exportData">
                   Export Data
@@ -337,7 +337,7 @@
 <script>
 import GlobalBar from "../../components/Charts/GlobalBar";
 import SectionCard from "../../components/Cards/SectionCard";
-import { getInteractionData, getAllRawCourse, getAllRawLab, getAllRawCapture, getAllDataRequest, exportMetricCsv, getDownloadLink, getCaptureJSONFile } from "../../requests/data";
+import { getInteractionData, getCombinedCourseCaptures, getCombinedLabCaptures, getCombinedCapture, getAllDataRequest, exportMetricCsv, getDownloadLink, downloadCaptureJSONFile } from "../../requests/data";
 import { getCourseListByInstructor, getLabList, getCaptureList } from "../../requests/course";
 import { Parser } from "json2csv";
 
@@ -475,6 +475,17 @@ export default {
     },
     getRawExportLabsByCourseId() {
       this.rawExportLabSelected = null;
+
+      if (!this.rawExportCourseSelected) {
+        this.rawExportLabSelected = null;
+        
+        this.rawExportCaptureSelected = null;
+
+        this.rawExportLabs = [];
+
+        return;
+      }
+
       getLabList({ courseId: this.rawExportCourseSelected }).then(res => {
         console.log(res);
         if (res.status == 200) {
@@ -503,7 +514,13 @@ export default {
       }
     },
     getRawExportCapturesByLabId() {
-      this.rawExportCaptureSelected = null;
+      if (!this.rawExportLabSelected) {
+        this.rawExportCaptureSelected = null;
+
+        this.rawExportCaptures = [];
+
+        return;
+      }
       getCaptureList({ labId: this.rawExportLabSelected }).then(res => {
         if (res.status == 200) {
           this.rawExportCaptures = res.data;
@@ -528,44 +545,24 @@ export default {
     },
     exportData() {
       let courseId = this.rawExportCourseSelected;
-      let labId = this.rawExportLabSelected;
-      let captureId = this.rawExportCaptureSelected;
 
-      if (courseId && labId && captureId) {
-        getCaptureJSONFile({ captureId });
-        /*.then(res => {
-          console.log(res);
-        });
-        */
-        /*
-        getAllRawCapture({ captureId }).then(res => {
-          if (res.status == 200) {
-            console.log(res.data)
-            this.formatAndDownload(res);
-          } else {
-            console.log(res);
-          }
-        });
-        */
-      } else if (courseId && labId) {
-        getAllRawLab({ labId }).then(res => {
-          if (res.status == 200) {
-            console.log(res.data)
-            this.formatAndDownload(res);
-          } else {
-            console.log(res);
-          }
-        });
-      } else if (courseId) {
-        getAllRawCourse({ courseId }).then(res => {
-          if (res.status == 200) {
-            console.log(res.data)
-            this.formatAndDownload(res);
-          } else {
-            console.log(res);
-          }
-        });
+      if (!courseId) {
+        return;
+      } 
+      
+      let labId = this.rawExportLabSelected;
+
+      if (!labId) {
+        return;
       }
+      
+      let captureId = this.rawExportCaptureSelected;
+        
+      if (!captureId) {
+        return;
+      }
+      
+      downloadCaptureJSONFile({ captureId });
     },
     formatAndDownload(res) {
       let intData = res.data.int;

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -25,7 +25,7 @@
     
     <v-row>
       <v-col>
-        <SectionCard title="Capture Data">
+        <SectionCard title="Raw Export">
           <v-container fluid>
             <template>
               <v-row>
@@ -38,8 +38,8 @@
                   :items="courses"
                   item-text="courseName"
                   item-value="courseId"
-                  v-model="courseSelected"
-                  v-on:change="getLabsByCourseId"
+                  v-model="rawExportCourseSelected"
+                  v-on:change="getRawExportLabsByCourseId"
                   dense 
                   class="ml-3"
                   clearable
@@ -48,13 +48,13 @@
                 </v-col>
                 <v-col>
                   <v-select
-                  v-if="courseSelected"
+                  v-if="rawExportCourseSelected"
                   label="Select Lab"
-                  :items="labs"
+                  :items="rawExportLabs"
                   item-text="sessionName"
                   item-value="sessionId"
-                  v-model="labSelected"
-                  v-on:change="getCapturesByLabId"
+                  v-model="rawExportLabSelected"
+                  v-on:change="getRawExportCapturesByLabId"
                   dense 
                   class="ml-3"
                   clearable
@@ -68,12 +68,12 @@
                 </v-col>
                 <v-col>
                   <v-select 
-                  v-if="labSelected"
+                  v-if="rawExportLabSelected"
                   label="Select Capture"
-                  :items="captures"
+                  :items="rawExportCaptures"
                   item-text="captureId"
                   item-value="captureId"
-                  v-model="captureSelected"
+                  v-model="rawExportCaptureSelected"
                   v-on:change="loadData"
                   dense class="ml-3"
                   clearable
@@ -87,7 +87,7 @@
                 </v-col>
 
                 <v-btn 
-                v-if="courseSelected" 
+                v-if="rawExportCourseSelected" 
                 color="primary" 
                 v-on:click="exportData">
                   Export Data
@@ -173,8 +173,8 @@
               :items="courses"
               item-text="courseName"
               item-value="courseId"
-              v-model="csvCourseSelected"
-              v-on:change="getcsvLabsByCourseId"
+              v-model="dataRequestCourseSelected"
+              v-on:change="getDataRequestLabsByCourseId"
               dense 
               class="ml-3"
               clearable
@@ -184,13 +184,13 @@
             </v-col>
             <v-col>
               <v-select
-              v-if="csvCourseSelected"
+              v-if="dataRequestCourseSelected"
               label="Select Lab"
-              :items="csvlabs"
+              :items="dataRequestLabs"
               item-text="sessionName"
               item-value="sessionId"
-              v-model="csvLabSelected"
-              v-on:change="getCsvCapturesByLabId"
+              v-model="dataRequestLabSelected"
+              v-on:change="getDataRequestCapturesByLabId"
               dense 
               class="ml-3"
               clearable
@@ -205,12 +205,12 @@
             </v-col>
             <v-col>
               <v-select 
-              v-if="csvLabSelected && csvCourseSelected"
+              v-if="dataRequestLabSelected && dataRequestCourseSelected"
               label="Select Capture"
-              :items="captures"
+              :items="dataRequestCaptures"
               item-text="captureId"
               item-value="captureId"
-              v-model="csvCaptureSelected"
+              v-model="dataRequestCaptureSelected"
               dense class="ml-3"
               clearable
               @change="changeRequest"
@@ -226,7 +226,7 @@
           <v-row>
             <v-col>
               <v-select 
-              v-if="csvLabSelected && csvCourseSelected"
+              v-if="dataRequestLabSelected && dataRequestCourseSelected"
               label="type"
               :items="type"
               v-model="typeSelected"
@@ -245,7 +245,7 @@
           <v-row>
             <v-col>
               <v-select
-              v-if="csvLabSelected && csvCourseSelected && (typeSelected =='user energy' || typeSelected =='aggregate interaction')"
+              v-if="dataRequestLabSelected && dataRequestCourseSelected && (typeSelected =='user energy' || typeSelected =='aggregate interaction')"
               label="Select interaction type"
               :items="interaction_type"
               item-text="text"
@@ -264,7 +264,7 @@
             </v-col>
             <v-col>
               <v-select
-              v-if="csvCourseSelected && csvLabSelected && typeSelected =='user energy'"
+              v-if="dataRequestCourseSelected && dataRequestLabSelected && typeSelected =='user energy'"
               label="Select entity type"
               :items="entity_type"
               item-text="text"
@@ -352,14 +352,16 @@ export default {
       userId: null,
       courses: [],
       courseSelected: null,
-      csvCourseSelected: null,
-      labs: [],
-      csvlabs: [],
-      labSelected: null,
-      csvLabSelected: null,
-      captures: [],
-      captureSelected: null,
-      csvCaptureSelected: null,
+      rawExportCourseSelected: null,
+      dataRequestCourseSelected: null,
+      rawExportLabs: [],
+      dataRequestLabs: [],
+      rawExportLabSelected: null,
+      dataRequestLabSelected: null,
+      rawExportCaptures: [],
+      dataRequestCaptures: [],
+      rawExportCaptureSelected: null,
+      dataRequestCaptureSelected: null,
       dataLoaded: false,
       search: '',
       interactions: [],
@@ -471,51 +473,51 @@ export default {
         this.courses = data.data;
       })
     },
-    getLabsByCourseId() {
-      this.labSelected = null;
-      getLabList({ courseId: this.courseSelected }).then(res => {
+    getRawExportLabsByCourseId() {
+      this.rawExportLabSelected = null;
+      getLabList({ courseId: this.rawExportCourseSelected }).then(res => {
         console.log(res);
         if (res.status == 200) {
-          this.labs = res.data;
+          this.rawExportLabs = res.data;
         } else {
           console.log(res);
         }
       })
     },
-    getcsvLabsByCourseId() {
-      this.csvlabSelected = null;
-      this.csvCaptureSelected = null;
+    getDataRequestLabsByCourseId() {
+      this.dataRequestLabSelected = null;
+      this.dataRequestCaptureSelected = null;
       this.submitDataRequest = true;
       this.typeSelected = null;
       this.entitySelected = null;
       this.interactionSelected = null;
-      if(this.csvCourseSelected!==null && this.csvCourseSelected!==undefined){
-        getLabList({ courseId: this.csvCourseSelected }).then(res => {
+      if(this.dataRequestCourseSelected!==null && this.dataRequestCourseSelected!==undefined){
+        getLabList({ courseId: this.dataRequestCourseSelected }).then(res => {
           console.log(res);
           if (res.status == 200) {
-            this.csvlabs = res.data;
+            this.dataRequestLabs = res.data;
           } else {
             console.log(res);
           }
         })
       }
     },
-    getCapturesByLabId() {
-      this.captureSelected = null;
-      getCaptureList({ labId: this.labSelected }).then(res => {
+    getRawExportCapturesByLabId() {
+      this.rawExportCaptureSelected = null;
+      getCaptureList({ labId: this.rawExportLabSelected }).then(res => {
         if (res.status == 200) {
-          this.csvCaptures = res.data;
+          this.rawExportCaptures = res.data;
         } else {
           console.log(res);
         }
       })
     },
-    getCsvCapturesByLabId() {
-      this.csvCaptureSelected = null;
+    getDataRequestCapturesByLabId() {
+      this.dataRequestCaptureSelected = null;
       this.submitDataRequest = true;
-      getCaptureList({ labId: this.csvLabSelected }).then(res => {
+      getCaptureList({ labId: this.dataRequestLabSelected }).then(res => {
         if (res.status == 200) {
-          this.captures = res.data;
+          this.dataRequestCaptures = res.data;
         } else {
           console.log(res);
         }
@@ -525,9 +527,9 @@ export default {
       this.dataLoaded = true;
     },
     exportData() {
-      let courseId = this.courseSelected;
-      let labId = this.labSelected;
-      let captureId = this.captureSelected;
+      let courseId = this.rawExportCourseSelected;
+      let labId = this.rawExportLabSelected;
+      let captureId = this.rawExportCaptureSelected;
 
       if (courseId && labId && captureId) {
         getAllRawCapture({ captureId }).then(res => {
@@ -584,7 +586,7 @@ export default {
           let encodedUri = encodeURI(intCsv);
           let link = document.createElement("a");
           link.setAttribute("href", encodedUri);
-          link.setAttribute("download", `${this.captureSelected || this.labSelected || this.courseSelected}_interactions.csv`);
+          link.setAttribute("download", `${this.rawExportCaptureSelected || this.rawExportLabSelected || this.rawExportCourseSelected}_interactions.csv`);
           document.body.appendChild(link); // Required for FF
           link.click();
         }
@@ -596,7 +598,7 @@ export default {
           let encodedUri = encodeURI(posCsv);
           let link = document.createElement("a");
           link.setAttribute("href", encodedUri);
-          link.setAttribute("download", `${this.captureSelected || this.labSelected || this.courseSelected}_positions.csv`);
+          link.setAttribute("download", `${this.rawExportCaptureSelected || this.rawExportLabSelected || this.rawExportCourseSelected}_positions.csv`);
           document.body.appendChild(link); // Required for FF
           link.click();
         }
@@ -663,9 +665,9 @@ export default {
     },
     getCsv() {
       let data = {
-        "sessionId": this.csvLabSelected,
+        "sessionId": this.dataRequestLabSelected,
         "clientId": this.userId,
-        "captureId": this.csvCaptureSelected,
+        "captureId": this.dataRequestCaptureSelected,
         "type": this.typeSelected,
         "interactionType": this.interactionSelected,
         "entityType": this.entitySelected
@@ -698,13 +700,13 @@ export default {
       }
     },
     changeRequest(){
-      if((this.csvLabSelected!==null && this.csvLabSelected!==undefined) && (this.csvCaptureSelected!==null && this.csvCaptureSelected!==undefined) && (this.interactionSelected!==null && this.interactionSelected!==undefined) && (this.entitySelected!==null && this.entitySelected!==undefined) && this.typeSelected =='user energy'){
+      if((this.dataRequestLabSelected!==null && this.dataRequestLabSelected!==undefined) && (this.dataRequestCaptureSelected!==null && this.dataRequestCaptureSelected!==undefined) && (this.interactionSelected!==null && this.interactionSelected!==undefined) && (this.entitySelected!==null && this.entitySelected!==undefined) && this.typeSelected =='user energy'){
         this.submitDataRequest = false;
       }
-      else if((this.csvLabSelected!==null && this.csvLabSelected!==undefined) && this.typeSelected =='aggregate interaction' && this.interactionSelected!==null && (this.csvCaptureSelected!==null && this.csvCaptureSelected!==undefined)){
+      else if((this.dataRequestLabSelected!==null && this.dataRequestLabSelected!==undefined) && this.typeSelected =='aggregate interaction' && this.interactionSelected!==null && (this.dataRequestCaptureSelected!==null && this.dataRequestCaptureSelected!==undefined)){
         this.submitDataRequest = false;
       }
-      else if((this.csvLabSelected!==null && this.csvLabSelected!==undefined) && this.typeSelected =='aggregate user' && (this.csvCaptureSelected!==null || this.csvCaptureSelected!==undefined)){
+      else if((this.dataRequestLabSelected!==null && this.dataRequestLabSelected!==undefined) && this.typeSelected =='aggregate user' && (this.dataRequestCaptureSelected!==null || this.dataRequestCaptureSelected!==undefined)){
         this.submitDataRequest = false;
       }
       else{

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -139,7 +139,7 @@
                 ></v-text-field>
               </v-row>
             </template>
-          </v-container fluid>
+          </v-container>
           <v-container fluid>
             <v-data-table
                   :headers="interactionTableHeaders"

--- a/frontend/src/pages/Metric/Metric.vue
+++ b/frontend/src/pages/Metric/Metric.vue
@@ -337,7 +337,7 @@
 <script>
 import GlobalBar from "../../components/Charts/GlobalBar";
 import SectionCard from "../../components/Cards/SectionCard";
-import { getInteractionData, getAllRawCourse, getAllRawLab, getAllRawCapture, getAllDataRequest, exportMetricCsv, getDownloadLink } from "../../requests/data";
+import { getInteractionData, getAllRawCourse, getAllRawLab, getAllRawCapture, getAllDataRequest, exportMetricCsv, getDownloadLink, getCaptureJSONFile } from "../../requests/data";
 import { getCourseListByInstructor, getLabList, getCaptureList } from "../../requests/course";
 import { Parser } from "json2csv";
 
@@ -532,6 +532,12 @@ export default {
       let captureId = this.rawExportCaptureSelected;
 
       if (courseId && labId && captureId) {
+        getCaptureJSONFile({ captureId });
+        /*.then(res => {
+          console.log(res);
+        });
+        */
+        /*
         getAllRawCapture({ captureId }).then(res => {
           if (res.status == 200) {
             console.log(res.data)
@@ -540,6 +546,7 @@ export default {
             console.log(res);
           }
         });
+        */
       } else if (courseId && labId) {
         getAllRawLab({ labId }).then(res => {
           if (res.status == 200) {

--- a/frontend/src/requests/data.js
+++ b/frontend/src/requests/data.js
@@ -1,32 +1,37 @@
 import baseRequest from "./base";
 
+const path = require("path");
+
 // Get metrics data
 export const getInteractionData = () => {
   return baseRequest.get("/data/interactions");
 };
 
 // Get raw position and interaction data by course id
-export const getAllRawCourse = params => {
+export const getCombinedCourseCaptures = params => {
   const { courseId } = params;
-  return baseRequest.get(`/data/export/raw/course/${courseId}`);
+  return baseRequest.get(`/data/export/combined/course/${courseId}`);
 };
 
 // Get raw position and interaction data by lab id
-export const getAllRawLab = params => {
+export const getCombinedLabCaptures = params => {
   const { labId } = params;
-  return baseRequest.get(`/data/export/raw/lab/${labId}`);
+  return baseRequest.get(`/data/export/combined/lab/${labId}`);
 };
 
 // Get raw position and interaction data by capture id
-export const getAllRawCapture = params => {
+export const getCombinedCapture = params => {
   const { captureId } = params;
-  return baseRequest.get(`/data/export/raw/capture/${captureId}`);
+  return baseRequest.get(`/data/export/combined/capture/${captureId}`);
 };
 
 // Get raw position and interaction data by capture id
-export const getCaptureJSONFile = params => {
+export const downloadCaptureJSONFile = params => {
   const { captureId } = params;
-  window.open(`/data/export/json/capture/${captureId}`);
+
+  let pathName = path.join("data", "export", "raw", "capture", captureId);
+
+  window.open(`${baseRequest.defaults.baseURL}${pathName}`);
 };
 
 //post params to get csv file for metric page

--- a/frontend/src/requests/data.js
+++ b/frontend/src/requests/data.js
@@ -23,17 +23,23 @@ export const getAllRawCapture = params => {
   return baseRequest.get(`/data/export/raw/capture/${captureId}`);
 };
 
+// Get raw position and interaction data by capture id
+export const getCaptureJSONFile = params => {
+  const { captureId } = params;
+  window.open(`/data/export/json/capture/${captureId}`);
+};
+
 //post params to get csv file for metric page
 export const exportMetricCsv = params => {
   return baseRequest.post("/data/", params);
-}
+};
 
 //Get data request by user id
 export const getAllDataRequest = params => {
   return baseRequest.post("/data/request", params);
-}
+};
 
 //Get download link by request id
 export const getDownloadLink = params => {
   return baseRequest.post("/data/download", params);
-}
+};

--- a/frontend/src/requests/data.js
+++ b/frontend/src/requests/data.js
@@ -7,24 +7,6 @@ export const getInteractionData = () => {
   return baseRequest.get("/data/interactions");
 };
 
-// Get raw position and interaction data by course id
-export const getCombinedCourseCaptures = params => {
-  const { courseId } = params;
-  return baseRequest.get(`/data/export/combined/course/${courseId}`);
-};
-
-// Get raw position and interaction data by lab id
-export const getCombinedLabCaptures = params => {
-  const { labId } = params;
-  return baseRequest.get(`/data/export/combined/lab/${labId}`);
-};
-
-// Get raw position and interaction data by capture id
-export const getCombinedCapture = params => {
-  const { captureId } = params;
-  return baseRequest.get(`/data/export/combined/capture/${captureId}`);
-};
-
 // Get raw position and interaction data by capture id
 export const downloadCaptureJSONFile = params => {
   const { captureId } = params;


### PR DESCRIPTION
# Raw export download (One capture at a time)

## Refactoring: Raw -> Combined; [JSON] -> Raw

* Combined export now refers to the legacy combination of multiple capture files under the same lab or course. 
    * This used to be called "raw".
* Raw export now means the export of a singular JSON capture file, including in this pull request.
    * This might have been called "JSON" export in some documentation or commits.

Fixes ??

### Type of change

Change that requires a documentation update
    
## New feature: Download a singular, raw capture file

Download a capture file as JSON.

Steps to test: 

Make sure you have a folder called `captures` on the same level as your `komodo-portal` folder. In that folder, you can have capture files with this path structure: `<session_id>\<timestamp>\data`.

Follow the readme to connect a Docker instance of `komodo-db` to your portal. Make sure the `captures` table has an entry where `capture_id = <session_id>_<timestamp>` and `session_id = <session_id>` that corresponds to the file you have.

1. Visit the Metrics page Data Capture section
2. Fill out the dropdowns
3. Press Export Data.

Expected result: a singular file called "data" is downloaded.

Workaround: to read the file, rename `data` to `<CustomNameHere>.json` and open it in a text editor or JSON viewer.

Fixes ??

### Type of change

New feature (non-breaking change which adds functionality)

## Bug fix: Clearing raw export dropdowns used to result in fatal error

Clearing raw export dropdowns no longer results in an SQL error. 

Steps to test: 

Make sure you have a folder called `captures` on the same level as your `komodo-portal` folder. In that folder, you can have capture files with this path structure: `<session_id>\<timestamp>\data`.

Follow the readme to connect a Docker instance of `komodo-db` to your portal. Make sure the `captures` table has an entry where `capture_id = <session_id>_<timestamp>` and `session_id = <session_id>` that corresponds to the file you have.

1. Go to the metrics page
2. Under Data Capture, select a course, lab, and/or capture.
3. Clear one or any of those fields.
4. Expected result 1: the back end remains running.
5. Expected result 2: the Export Data button is enabled if and only if all three dropdowns are selected.

Fixes ??

### Type of change

Bug fix (non-breaking change which fixes an issue)

## Deprecation: Legacy combined exports are deprecated

The related API endpoints have been removed, as well as the function that processes the legacy packed array format for positions and interactions. A branch with these features has been created, and it is called `feature/raw-combined-export`. (Search for a commit where `Metric.vue` has a `formatAndDownload` function.)

# How Has This Been Tested?

See above for manual tests.

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test

**Test Configuration**:

* Chrome 96.0.x (Official Build) (64-bit)

# Checklist:

- [ ] ~~My code follows the style guidelines of this project~~
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas that are not self-documenting
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings 
- [x] My changes have no unnecessary logging
- [x] I have added tests that prove my fix is effective or that my feature works, for sufficiently complex features
- [ ] ~~New and existing unit tests pass locally with my changes~~
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Sensitive info like tokens, secrets, and passwords have been removed before submitting

Modified from this article:
Phillip Johnston, “A GitHub Pull Request Template for Your Projects - Embedded Artistry,” Embedded Artistry, Aug. 04, 2017. https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ (accessed Jul. 22, 2021).
