### PR TITLE
Introduced docker-compose overrides for networking

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,22 @@
+# This Docker (manual) override file opens ports and disables traefik.
+
+# examples of using this file: 
+#   DEVELOPMENT ONLY. PROCEED WITH CAUTION, BECAUSE IT WILL OPEN PORTS: 
+#     $ docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build frontend
+#     $ docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build backend
+#     $ docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --build 
+
+version: '3.3'
+services:
+
+  backend:
+    labels:
+      - "traefik.enable=false"
+    ports:
+      - 4040:4040
+
+  frontend:
+    labels:
+      - "traefik.enable=false"
+    ports: 
+      - 8080:80

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,35 @@
+# This Docker (auto) override file creates top-level networks and connects to them in the service level.
+
+# examples of using this file: 
+#     $ docker-compose up --build
+#     $ docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build
+
+version: '3.3'
+services:
+
+  backend:
+    labels:
+      - "traefik.frontend.rule=Host:api.komodo-dev.library.illinois.edu"
+      - "traefik.backend=komodo-portal-backend"
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+      - "traefik.port=4040"
+    networks:
+      - proxy
+      - komodo_internal
+
+  frontend:
+    labels:
+      - "traefik.frontend.rule=Host:komodo-dev.library.illinois.edu"
+      - "traefik.backend=komodo-portal-frontend"
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+    networks:
+      - proxy
+      - komodo_internal
+
+networks:
+  proxy:
+    external: true
+  komodo_internal:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,11 @@
+# This Docker compose file serves as a base. To use it with networks, please see...
+# - docker-compose.override.yml
+# - docker-compose.dev.yml
+
+# examples of using this file: 
+#     $ docker-compose up --build
+#     $ docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build
+
 version: '3.3'
 services:
 
@@ -5,33 +13,10 @@ services:
     build: ./backend
     container_name: komodo-portal-backend
     restart: always
-    labels:
-      - "traefik.frontend.rule=Host:api.komodo-dev.library.illinois.edu"
-      - "traefik.backend=komodo-portal-backend"
-      - "traefik.enable=true"
-      - "traefik.docker.network=proxy"
-      - "traefik.port=4040"
-    networks:
-      - proxy
-      - komodo_internal
 
   frontend:
     build: ./frontend
     container_name: komodo-portal-frontend
     restart: always
-    labels:
-      - "traefik.frontend.rule=Host:komodo-dev.library.illinois.edu"
-      - "traefik.backend=komodo-portal-frontend"
-      - "traefik.enable=true"
-      - "traefik.docker.network=proxy"
     environment:
       - VUE_APP_API_BASE_URL 
-    networks:
-      - proxy
-      - komodo_internal
-
-networks:
-  proxy:
-    external: true
-  komodo_internal:
-    external: true


### PR DESCRIPTION
# Introduced docker-compose overrides for networking

This makes it easier to run the portal with docker-compose locally without having to edit the docker-compose file (and without having to discard those edits when committing changes).

Further reading:

“Share Compose configurations between files and projects,” Docker Documentation, Mar. 29, 2022. https://docs.docker.com/compose/extends/#understanding-multiple-compose-files (accessed Mar. 29, 2022).

C. Laine, “Making sense of Docker Compose overrides - IT Dead Inside,” Medium, Sep. 2019. https://medium.com/it-dead-inside/making-sense-of-docker-compose-overrides-efb757460d64 (accessed Mar. 29, 2022).
‌
‌
![docker-compose-override-explanations](https://user-images.githubusercontent.com/8165314/160723180-92c33012-ea74-4d06-94cf-68b9fc0a0cac.png)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Testing 
- [x] Change that requires a documentation update

# How Has This Been Tested?

Run the docker-compose commands included in the new `docker-compose.*yml files`.

* Run docker-compose and specify base compose with dev compose
* Expected result: can access back end on localhost:4040 (for example) or front end on localhost:8080 (for example) in browser on host machine

* Run docker-compose without specifying any compose files
* Expected result: cannot access back end or front end in browser on host machine

- [x] Manual Test
- [ ] Unit Test
- [ ] Integration / End-to-End Test

**Test Configuration**:

Docker Desktop (for Windows but with Linux containers)

Command Prompt

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas that are not self-documenting
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings 
- [x] My changes have no unnecessary logging
- [x] I have added tests that prove my fix is effective or that my feature works, for sufficiently complex features
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Sensitive info like tokens, secrets, and passwords have been removed before submitting

Modified from this article:
Phillip Johnston, “A GitHub Pull Request Template for Your Projects - Embedded Artistry,” Embedded Artistry, Aug. 04, 2017. https://embeddedartistry.com/blog/2017/08/04/a-github-pull-request-template-for-your-projects/ (accessed Jul. 22, 2021).
